### PR TITLE
Add README and improve navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Lernskript Mathematik 2
+
+Dieses Repository enthält ein webbasiertes Lernskript. Die Kapitel liegen im Ordner `chapters/` und werden über `index.html` aufgerufen.
+
+## Struktur
+* `index.html` – Startseite mit Inhaltsverzeichnis
+* `chapters/` – einzelne Kapitel
+* `style.css` – gemeinsames Layout
+* `main.js` – Skript für Dark Mode, Navigation und Zurück-zum-Anfang
+* `images/` – Platzhaltergrafiken
+* `scripts/update-head.js` – kleines Buildskript
+* `templates/head-fragment.html` – gemeinsamer HTML-Head
+
+## Buildskript
+Mit `node scripts/update-head.js` wird der gemeinsame Teil des `<head>`-Bereichs aller Kapitel anhand von `templates/head-fragment.html` aktualisiert.
+
+## Verwendung
+`index.html` im Browser öffnen. Auf der Startseite wird automatisch das aktuelle Datum angezeigt. In jedem Kapitel gibt es Vor/Zurück-Navigation und einen Button nach oben. Ein Klick auf das Mondsymbol aktiviert den Dark Mode.

--- a/chapters/13-fourierreihen.html
+++ b/chapters/13-fourierreihen.html
@@ -127,10 +127,10 @@
             </li>
         </ul>
         
-        <div class="image-placeholder">
-             <p><strong>Visuelle Hilfe: Approximation des Rechtecksignals</strong></p>
-             <p>(Hier wäre eine Grafik ideal, die zeigt, wie das Originalsignal durch $F_1(x)$, $F_3(x)$ und $F_5(x)$ immer besser angenähert wird. Man würde die Grundschwingung und die ersten Oberschwingungen sehen.)</p>
-        </div>
+        <figure class="image-placeholder">
+            <img src="../images/placeholder.svg" alt="Approximation des Rechtecksignals"/>
+            <figcaption>Approximation des Rechtecksignals durch erste Oberschwingungen</figcaption>
+        </figure>
         <div class="info-box tip">
             <h5>Interessantes Detail: Das Gibbs-Phänomen</h5>
             <p>Wenn man eine Fourierreihe zur Annäherung einer Funktion mit einer Sprungstelle (wie dem Rechtecksignal) verwendet, wird man feststellen, dass die Näherung an der Sprungstelle immer leicht "überschießt".</p>

--- a/chapters/14-dgl.html
+++ b/chapters/14-dgl.html
@@ -68,10 +68,10 @@
             <h5>Praxis-Tipp: Geometrische Deutung als Richtungsfeld</h5>
             <p>Eine DGL 1. Ordnung wie $y' = f(x,y)$ lässt sich visualisieren. Sie ordnet jedem Punkt $(x,y)$ der Ebene eine Steigung $y'$ zu. Man kann dies als ein Feld von kleinen Pfeilen (ein "Richtungsfeld") zeichnen.</p>
             <p>Eine Lösung der DGL zu finden bedeutet dann, eine Kurve zu finden, die sich "stromlinienförmig" in dieses Richtungsfeld einfügt, d.h., sie hat an jedem Punkt genau die Steigung, die der Pfeil an diesem Punkt vorgibt. Ein Anfangswertproblem legt dabei den Startpunkt der Kurve fest.</p>
-            <div class="image-placeholder" style="margin-top: 15px;">
-                <p><strong>Visuelle Hilfe: Richtungsfeld und Lösungskurven</strong></p>
-                <p>(Hier wäre eine Grafik ideal, die z.B. das Richtungsfeld für $y'=-x/y$ zeigt – ein Feld von Pfeilen – und dazu einige Lösungskurven – Kreise – die sich an das Feld anpassen.)</p>
-            </div>
+                <figure class="image-placeholder" style="margin-top: 15px;">
+                    <img src="../images/placeholder.svg" alt="Richtungsfeld und Loesungskurven"/>
+                    <figcaption>Richtungsfeld mit typischen Loesungskurven</figcaption>
+                </figure>
             </div>
         
         <dl>

--- a/chapters/15-klausurvorbereitung.html
+++ b/chapters/15-klausurvorbereitung.html
@@ -90,9 +90,10 @@
             <li><strong>b)</strong> (8 P) Leiten Sie das Taylorpolynom 2. Grades von $ f(x) = \frac{1}{\sqrt{2x+1}} $ um den Entwicklungspunkt $ x_0 = 3 $ durch explizite Berechnung der Taylorkoeffizienten her. Inwiefern ist dieses das beste Polynom 2. Grades zu f?</li>
         </ul>
         <h5>Aufgabe 1.4 (14P) Fourierreihen</h5>
-        <div class="image-placeholder">
-            <p>(Hier wäre die Skizze des periodischen Signals aus der Originalklausur. Annahme für die Aufgabe: Ein Sägezahnsignal, das auf $[-\pi, \pi)$ durch $f(x)=x/2$ definiert ist und die Periode $T=2\pi$ hat.)</p>
-        </div>
+        <figure class="image-placeholder">
+            <img src="../images/placeholder.svg" alt="Skizze periodisches Signal"/>
+            <figcaption>Skizze des Signals aus der Aufgabe</figcaption>
+        </figure>
         <p>Stellen Sie für den im Originaldokument skizzierten Verlauf eines periodischen Signals eine Funktionsvorschrift auf. Von den zugehörigen Fourierkoeffizienten ist bekannt: $$ a_n = \frac{(-1)^n - 1}{n^2\pi^2}, \quad b_n = \frac{(-1)^{n+1}}{n\pi} \quad (n \ge 1) $$ Leiten Sie $a_0$ und $a_n$ (n $\ge$ 1) her. Geben Sie das Fourierpolynom $F_m(x)$ für $m=2$ explizit an. Inwiefern ist $F_2$ bzgl. des Ausdrucks $\frac{2}{T}\int_{T} (f(x)-F_m(x))^2 dx$ bestmöglich und was kann man sich anschaulich darunter vorstellen?</p>
         
         <h4>15.2.2 Beispiel 2</h4>

--- a/images/placeholder.svg
+++ b/images/placeholder.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="200">
+  <rect width="400" height="200" fill="#ddd" />
+  <text x="200" y="105" font-size="20" text-anchor="middle" fill="#555">Bild folgt</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
         <h1>Lerneinheiten zur Mathematik</h1>
         <div class="title-meta">
             <div class="author">Dein persönlicher KI-Mathe-Tutor</div>
-            <div class="date">22. Juni 2025</div>
+            <time id="current-date" class="date" data-dynamic="true"></time>
         </div>
 
         <nav class="toc">

--- a/main.js
+++ b/main.js
@@ -27,6 +27,24 @@ document.addEventListener('DOMContentLoaded', () => {
         const savedTheme = localStorage.getItem('theme') || 'light';
         applyTheme(savedTheme);
     }
+    // --- Dynamic Date ---
+    const dateElem = document.querySelector(".date[data-dynamic]");
+    if (dateElem) {
+        const now = new Date();
+        const fmt = new Intl.DateTimeFormat("de-DE", { day: "numeric", month: "long", year: "numeric" });
+        dateElem.textContent = fmt.format(now);
+        dateElem.setAttribute("datetime", now.toISOString());
+    }
+
+    // --- Top Navigation ---
+    const footerNav = document.querySelector("footer .page-nav");
+    const header = document.querySelector("header.page-header");
+    if (footerNav && header) {
+        const topNav = footerNav.cloneNode(true);
+        topNav.classList.add("top");
+        header.insertAdjacentElement("afterend", topNav);
+    }
+
 
 
     // --- Back to Top Button ---

--- a/scripts/update-head.js
+++ b/scripts/update-head.js
@@ -1,0 +1,13 @@
+const fs = require('fs');
+const path = require('path');
+
+const fragment = fs.readFileSync(path.join(__dirname, '..', 'templates', 'head-fragment.html'), 'utf8').trim();
+const chaptersDir = path.join(__dirname, '..', 'chapters');
+
+for (const file of fs.readdirSync(chaptersDir)) {
+  if (!file.endsWith('.html')) continue;
+  const filePath = path.join(chaptersDir, file);
+  let html = fs.readFileSync(filePath, 'utf8');
+  html = html.replace(/<script id="MathJax-script"[\s\S]*?<link rel="stylesheet" href="\.\.\/style.css">/, fragment);
+  fs.writeFileSync(filePath, html);
+}

--- a/style.css
+++ b/style.css
@@ -284,6 +284,9 @@ footer {
     display: flex;
     justify-content: space-between;
 }
+.page-nav.top {
+    margin: 1rem 0;
+}
 .page-nav a {
     font-weight: 600;
     padding: 8px 16px;
@@ -368,7 +371,7 @@ footer {
     background-color: var(--bg-color-subtle);
 }
 
-.image-placeholder {
+figure.image-placeholder {
     border: 2px dashed var(--border-color);
     padding: 2.5rem;
     text-align: center;

--- a/templates/head-fragment.html
+++ b/templates/head-fragment.html
@@ -1,0 +1,5 @@
+<script>
+  MathJax = { tex: { inlineMath: [['$', '$'], ['\\(', '\\)']], displayMath: [['$$', '$$'], ['\\[', '\\]']], processEscapes: true }, svg: { fontCache: 'global' } };
+</script>
+<script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js"></script>
+<link rel="stylesheet" href="../style.css">


### PR DESCRIPTION
## Summary
- show current date on the start page
- clone the next/previous navigation to the top of every chapter
- style the new navigation position and convert image placeholders to figures
- add placeholder SVG and small build script
- document project layout in a README

## Testing
- `node scripts/update-head.js`

------
https://chatgpt.com/codex/tasks/task_e_685861470918832fb86df702e2ce3ed8