### PR TITLE
Update style for improved look

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,12 +1,13 @@
 /* ==========================================================================
    Modernes & sauberes CSS für das Lernskript
    ========================================================================== */
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap');
 
 /* 1. Globale Einstellungen und Farbvariablen
    -------------------------------------------------------------------------- */
 :root {
     /* Schriftarten */
-    --font-sans: 'Segoe UI', -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif;
+    --font-sans: 'Inter', 'Segoe UI', -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif;
     --font-serif: 'Georgia', 'Times New Roman', Times, serif;
     --font-mono: 'SF Mono', 'Consolas', 'Menlo', 'Courier New', Courier, monospace;
     
@@ -176,10 +177,11 @@ pre {
     left: 0;
     width: 100%;
     height: var(--header-height);
-    background-color: var(--bg-color-subtle);
+    background: linear-gradient(to right, var(--primary-color-dark), var(--primary-color));
+    color: #fff;
     z-index: 1000;
     padding: 0 2rem;
-    box-shadow: 0 2px 10px rgba(0,0,0,0.05);
+    box-shadow: 0 2px 10px rgba(0,0,0,0.1);
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -188,8 +190,9 @@ pre {
 .page-header a {
     font-weight: 600;
     font-size: 1.1rem;
+    color: #fff;
 }
-.page-header a:hover { text-decoration: none; }
+.page-header a:hover { text-decoration: underline; }
 .header-controls {
     display: flex;
     align-items: center;
@@ -420,7 +423,7 @@ body.dark-mode summary:hover { background-color: var(--bg-color-main); }
     font-size: 1.5rem;
     cursor: pointer;
     padding: 0 10px;
-    color: var(--text-color);
+    color: inherit;
     transition: transform var(--transition-speed);
 }
 #dark-mode-toggle:hover {


### PR DESCRIPTION
## Summary
- load Google Font `Inter`
- switch site font to `Inter`
- apply a gradient header and white navigation links
- inherit header color for the dark-mode toggle

## Testing
- `node scripts/update-head.js`

------
https://chatgpt.com/codex/tasks/task_e_685933b4697c832f8a194d42b17c2592