### PR TITLE
Link training pages to main chapters

### DIFF
--- a/chapters/02-kombinationen.html
+++ b/chapters/02-kombinationen.html
@@ -213,6 +213,7 @@
     <footer>
         <nav class="page-nav" aria-label="Seitennavigation">
             <a href="01-zaehlprinzipien.html">← Vorheriges Kapitel</a>
+            <a href="training/02-uebungen_kombinationen.html">Zu den Übungen</a>
             <a href="03-folgen-einfuehrung.html">Nächstes Kapitel →</a>
         </nav>
     </footer>

--- a/chapters/03-folgen-einfuehrung.html
+++ b/chapters/03-folgen-einfuehrung.html
@@ -185,6 +185,7 @@
     <footer>
         <nav class="page-nav" aria-label="Seitennavigation">
             <a href="02-kombinationen.html">← Vorheriges Kapitel</a>
+            <a href="training/03-uebungen-folgen-einfuehrung.html">Zu den Übungen</a>
             <a href="04-grenzwerte.html">Nächstes Kapitel →</a>
         </nav>
     </footer>

--- a/chapters/04-grenzwerte.html
+++ b/chapters/04-grenzwerte.html
@@ -172,6 +172,7 @@
     <footer>
         <nav class="page-nav" aria-label="Seitennavigation">
             <a href="03-folgen-einfuehrung.html">← Vorheriges Kapitel</a>
+            <a href="training/04-uebungen-grenzwerte.html">Zu den Übungen</a>
             <a href="05-ableitung-einfuehrung.html">Nächstes Kapitel →</a>
         </nav>
     </footer>

--- a/chapters/05-ableitung-einfuehrung.html
+++ b/chapters/05-ableitung-einfuehrung.html
@@ -174,6 +174,7 @@
     <footer>
         <nav class="page-nav" aria-label="Seitennavigation">
             <a href="04-grenzwerte.html">← Vorheriges Kapitel</a>
+            <a href="training/05-uebungen-ableitung-einfuehrung.html">Zu den Übungen</a>
             <a href="06-anwendungen-ableitung.html">Nächstes Kapitel →</a>
         </nav>
     </footer>

--- a/chapters/06-ableitungsregeln.html
+++ b/chapters/06-ableitungsregeln.html
@@ -157,6 +157,7 @@
     <footer>
         <nav class="page-nav" aria-label="Seitennavigation">
             <a href="05-ableitung-einfuehrung.html">← Vorheriges Kapitel</a>
+            <a href="training/06-uebungen-ableitungsregeln.html">Zu den Übungen</a>
             <a href="07-partielle-ableitungen.html">Nächstes Kapitel →</a>
         </nav>
     </footer>

--- a/chapters/training/03-uebungen-folgen-einfuehrung.html
+++ b/chapters/training/03-uebungen-folgen-einfuehrung.html
@@ -125,7 +125,7 @@
     
     <footer>
         <nav class="page-nav" aria-label="Seitennavigation">
-            <a href="../02-kombinationen.html">← Vorheriges Kapitel</a>
+            <a href="../03-folgen-einfuehrung.html">← Zurück zum Kapitel</a>
             <a href="../04-grenzwerte.html">Nächstes Kapitel →</a>
         </nav>
     </footer>

--- a/chapters/training/04-uebungen-grenzwerte.html
+++ b/chapters/training/04-uebungen-grenzwerte.html
@@ -98,7 +98,7 @@
 
     <footer>
         <nav class="page-nav" aria-label="Seitennavigation">
-            <a href="../03-folgen-einfuehrung.html">← Vorheriges Kapitel</a>
+            <a href="../04-grenzwerte.html">← Zurück zum Kapitel</a>
             <a href="../05-ableitung-einfuehrung.html">Nächstes Kapitel →</a>
         </nav>
     </footer>

--- a/chapters/training/06-uebungen-ableitungsregeln.html
+++ b/chapters/training/06-uebungen-ableitungsregeln.html
@@ -101,8 +101,8 @@
 
     <footer>
         <nav class="page-nav" aria-label="Seitennavigation">
-            <a href="../08-extremwerte-mehrere-var.html">← Zurück zum Kapitel</a>
-            <a href="../10-integralrechnung.html">Nächstes Kapitel →</a>
+            <a href="../06-ableitungsregeln.html">← Zurück zum Kapitel</a>
+            <a href="../07-partielle-ableitungen.html">Nächstes Kapitel →</a>
         </nav>
     </footer>
 


### PR DESCRIPTION
## Summary
- connect theory chapters with their exercise pages
- link exercise pages back to the theory chapters
- fix navigation on the last exercise page

## Testing
- `npm run build`
- `npm run check-pdfs`

------
https://chatgpt.com/codex/tasks/task_e_685995ea8128832f9670767f6b6c8bca